### PR TITLE
Change devtools to remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can install ggkeyboard from github:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("sharlagelfand/ggkeyboard", ref = "main")
+remotes::install_github("sharlagelfand/ggkeyboard", ref = "main")
 ```
 
 Plot a keyboard using `ggkeyboard()`. The default is very cute:


### PR DESCRIPTION
Beautiful package. I suggest changing `devtools::install_github` to `remotes::install_github`, as remotes is much lighter and focused only on installing from Github & similar