### PR TITLE
Fix type mismatch in text_colour_adjust case_when (fixes #13)

### DIFF
--- a/R/ggkeyboard.R
+++ b/R/ggkeyboard.R
@@ -253,8 +253,8 @@ text_colour_adjust <- function(fill, text_colour, adjust_text_colour) {
   fill_dark <- is_dark(fill)
   text_colour_dark <- is_dark(text_colour)
 
-  dplyr::case_when(fill_dark & adjust_text_colour & text_colour_dark ~ prismatic::clr_lighten(text_colour),
-                   !fill_dark & adjust_text_colour & !text_colour_dark ~ prismatic::clr_darken(text_colour),
+  dplyr::case_when(fill_dark & adjust_text_colour & text_colour_dark ~ as.character(prismatic::clr_lighten(text_colour)),
+                   !fill_dark & adjust_text_colour & !text_colour_dark ~ as.character(prismatic::clr_darken(text_colour)),
                    TRUE ~ text_colour)
 }
 


### PR DESCRIPTION
`ggkeyboard()` was throwing a type mismatch error in `case_when()` because `prismatic::clr_lighten()` and `clr_darken()` return a `<colors>` object while the fallback branch returns plain `<character>`. Newer versions of dplyr require all right-hand sides of `case_when()` to be the same type.

Fix: wrap both prismatic calls in `as.character()`